### PR TITLE
Add link.xml to avoid stripping on builtin components

### DIFF
--- a/Assets/link.xml
+++ b/Assets/link.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="UnityEngine">
+    <type fullname="UnityEngine.Light" preserve="all" />
+    <type fullname="UnityEngine.ParticleSystem" preserve="all" />
+  </assembly>
+</linker>

--- a/Assets/link.xml.meta
+++ b/Assets/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6cf879555da4144b78446cd8708180a6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request is to solve an issue where Generic Output nodes fail to access some of the builtin components.

---

The Klak Wiring system uses C# reflection to access components, so that it's prone to cause issues with bytecode stripping.

https://docs.unity3d.com/Manual/IL2CPP-BytecodeStripping.html

For instance, when using `FloatOut` to change values on a `Light` component or a `ParticleSystem` component, it works correctly on Editor:

![ok](https://i.imgur.com/9E2pqlh.gif)

(`Light.intensity` and `ParticleSystem.startSize` are driven by a Noise node)

...but fails on built apps.

![ng](https://i.imgur.com/u1jTqTJ.gif)

This can be solved by adding `link.xml` to exclude these components from bytecode stripping.

Probably there are some more components that should be added to the stripping blacklist. At the moment, I only found these two components not working, and these features are especially important for Videolab.

Note that this `link.xml` should also be added to the OP-Z app project.