### PR TITLE
New component-out nodes for Unity 2018

### DIFF
--- a/Assets/Klak/Wiring/Editor/Output/PlayableDirectorOutEditor.cs
+++ b/Assets/Klak/Wiring/Editor/Output/PlayableDirectorOutEditor.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace Klak.Wiring
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(PlayableDirectorOut))]
+    public class PlayableDirectorOutEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            DrawPropertiesExcluding(serializedObject, new string[] {"m_Script"});
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Klak/Wiring/Editor/Output/PlayableDirectorOutEditor.cs.meta
+++ b/Assets/Klak/Wiring/Editor/Output/PlayableDirectorOutEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1763c129abcea4dbf9c1328f8ce3d881
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Klak/Wiring/Editor/Output/VideoPlayerOutEditor.cs
+++ b/Assets/Klak/Wiring/Editor/Output/VideoPlayerOutEditor.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace Klak.Wiring
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(VideoPlayerOut))]
+    public class VideoPlayerOutEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            DrawPropertiesExcluding(serializedObject, new string[] {"m_Script"});
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Klak/Wiring/Editor/Output/VideoPlayerOutEditor.cs.meta
+++ b/Assets/Klak/Wiring/Editor/Output/VideoPlayerOutEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 243efcbdbf4ab4b37867d7e8bb034f21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Klak/Wiring/Output/PlayableDirectorOut.cs
+++ b/Assets/Klak/Wiring/Output/PlayableDirectorOut.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace Klak.Wiring
+{
+    [AddComponentMenu("Klak/Wiring/Output/Component/Playable Director Out")]
+    public class PlayableDirectorOut : NodeBase
+    {
+        #region Editable properties
+
+        [SerializeField]
+        PlayableDirector _playableDirector;
+
+        #endregion
+
+        #region Node I/O
+
+        [Inlet]
+        public float speed {
+            set {
+                if (!enabled || _playableDirector == null) return;
+                var graph = _playableDirector.playableGraph;
+                if (!graph.IsValid()) return;
+                for (var i = 0; i < graph.GetRootPlayableCount(); i++)
+                    graph.GetRootPlayable(i).SetSpeed(value);
+            }
+        }
+
+        [Inlet]
+        public float time {
+            set {
+                if (!enabled || _playableDirector == null) return;
+                _playableDirector.time = value;
+            }
+        }
+
+        [Inlet]
+        public float normalizedTime {
+            set {
+                if (!enabled || _playableDirector == null) return;
+                _playableDirector.time = _playableDirector.duration * value;
+            }
+        }
+
+        [Inlet]
+        public void Play()
+        {
+            if (!enabled || _playableDirector == null) return;
+            _playableDirector.Play();
+            _playableDirector.time = 0;
+        }
+
+        [Inlet]
+        public void Stop()
+        {
+            if (!enabled || _playableDirector == null) return;
+            _playableDirector.Stop();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Klak/Wiring/Output/PlayableDirectorOut.cs.meta
+++ b/Assets/Klak/Wiring/Output/PlayableDirectorOut.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a384bc1f514fc4d6e8a0955ad05aa3dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Klak/Wiring/Output/VideoPlayerOut.cs
+++ b/Assets/Klak/Wiring/Output/VideoPlayerOut.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEngine.Video;
+
+namespace Klak.Wiring
+{
+    [AddComponentMenu("Klak/Wiring/Output/Component/Video Player Out")]
+    public class VideoPlayerOut : NodeBase
+    {
+        #region Editable properties
+
+        [SerializeField]
+        VideoPlayer _videoPlayer;
+
+        #endregion
+
+        #region Node I/O
+
+        [Inlet]
+        public float speed {
+            set {
+                if (!enabled || _videoPlayer == null) return;
+                _videoPlayer.playbackSpeed = value;
+            }
+        }
+
+        [Inlet]
+        public float time {
+            set {
+                if (!enabled || _videoPlayer == null) return;
+                _videoPlayer.time = value;
+            }
+        }
+
+        [Inlet]
+        public float normalizedTime {
+            set {
+                if (!enabled || _videoPlayer == null) return;
+                _videoPlayer.time = _videoPlayer.clip.length * value;
+            }
+        }
+
+        [Inlet]
+        public void Play()
+        {
+            if (!enabled || _videoPlayer == null) return;
+            if (_videoPlayer.isPlaying)
+                _videoPlayer.time = 0;
+            else
+                _videoPlayer.Play();
+        }
+
+        [Inlet]
+        public void Stop()
+        {
+            if (!enabled || _videoPlayer == null) return;
+            _videoPlayer.Stop();
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Klak/Wiring/Output/VideoPlayerOut.cs.meta
+++ b/Assets/Klak/Wiring/Output/VideoPlayerOut.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c58f1bad01174fa18df1edc6af2cb60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request is to add new component-out node types that work with some of the new features in Unity 2017/2018.

- VideoPlayerOut - Controls video playback on a VideoPlayer component.
- PlayableDirectorOut - Controls timeline playback on a PlayableDirector component.

These two components are commonly used in audio visual applications, and some of the properties in these components are not accessible from generic-out nodes (due to the type restriction of generic-out; double/long properties are not accessible), so it's considered important to add these new node types to the library.