### PR TITLE
change .rsp file comment char to fix package import script build failure

### DIFF
--- a/Assets/csc.rsp
+++ b/Assets/csc.rsp
@@ -1,3 +1,3 @@
 ﻿
-% Silence warning about serialized fields not being assigned
+#"Silence warning about serialized fields not being assigned"
 -nowarn:0649


### PR DESCRIPTION
Currently, the way the comment is formatted causes build errors during unitypackage import. The right click options in the hierarchy are not visible because all script compilation halted. This fixes that.

See this comment on unity forums: http://answers.unity.com/answers/1630246/view.html

Hotfix example package: https://www.dropbox.com/s/cnrqydrnn7na6ml/videolab-1.1.1-hotfix.unitypackage?dl=1

Examples that cause compilation to fail (on my unity 2018.4.20f1, macOS Catalina):

```
% this comment causes build fail
# this comment causes build fail
#this comment causes build fail
```

See comment in this issue for more discussion: https://github.com/teenageengineering/videolab/issues/32#issuecomment-608415693