### PR TITLE
Threshold node update

### DIFF
--- a/Assets/Klak/Wiring/Editor/Filter/ThresholdEditor.cs
+++ b/Assets/Klak/Wiring/Editor/Filter/ThresholdEditor.cs
@@ -31,16 +31,16 @@ namespace Klak.Wiring
     public class ThresholdEditor : Editor
     {
         SerializedProperty _threshold;
-        SerializedProperty _delayToOff;
         SerializedProperty _onEvent;
         SerializedProperty _offEvent;
+        SerializedProperty _discrete;
 
         void OnEnable()
         {
             _threshold = serializedObject.FindProperty("_threshold");
-            _delayToOff = serializedObject.FindProperty("_delayToOff");
             _onEvent = serializedObject.FindProperty("_onEvent");
             _offEvent = serializedObject.FindProperty("_offEvent");
+            _discrete = serializedObject.FindProperty("_discrete");
         }
 
         public override void OnInspectorGUI()
@@ -48,7 +48,7 @@ namespace Klak.Wiring
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(_threshold);
-            EditorGUILayout.PropertyField(_delayToOff);
+            EditorGUILayout.PropertyField(_discrete);
 
             EditorGUILayout.Space();
 

--- a/Assets/Klak/Wiring/Editor/Filter/ThresholdEditor.cs
+++ b/Assets/Klak/Wiring/Editor/Filter/ThresholdEditor.cs
@@ -31,6 +31,7 @@ namespace Klak.Wiring
     public class ThresholdEditor : Editor
     {
         SerializedProperty _threshold;
+        SerializedProperty _delayToOff;
         SerializedProperty _onEvent;
         SerializedProperty _offEvent;
         SerializedProperty _discrete;
@@ -38,6 +39,7 @@ namespace Klak.Wiring
         void OnEnable()
         {
             _threshold = serializedObject.FindProperty("_threshold");
+            _delayToOff = serializedObject.FindProperty("_delayToOff");
             _onEvent = serializedObject.FindProperty("_onEvent");
             _offEvent = serializedObject.FindProperty("_offEvent");
             _discrete = serializedObject.FindProperty("_discrete");
@@ -48,8 +50,10 @@ namespace Klak.Wiring
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(_threshold);
-            EditorGUILayout.PropertyField(_discrete);
+            EditorGUILayout.PropertyField(_delayToOff);
 
+            EditorGUILayout.Space();
+            EditorGUILayout.PropertyField(_discrete);
             EditorGUILayout.Space();
 
             EditorGUILayout.PropertyField(_onEvent);

--- a/Assets/Klak/Wiring/Filter/Threshold.cs
+++ b/Assets/Klak/Wiring/Filter/Threshold.cs
@@ -34,7 +34,7 @@ namespace Klak.Wiring
         float _threshold = 0.01f;
 
         [SerializeField]
-        float _delayToOff = 0.0f;
+        bool _discrete = false;
 
         #endregion
 
@@ -47,11 +47,33 @@ namespace Klak.Wiring
 
                 _currentValue = value;
 
+                if (_discrete)
+                {
+                    _currentState = State.Dormant;
+                }
+
                 if (_currentValue >= _threshold &&
                     _currentState != State.Enabled)
                 {
                     _onEvent.Invoke();
-                    _currentState = State.Enabled;
+                    
+                    if (!_discrete)         //Makes sure _currentState stays Dormant in discrete mode so that
+                                            //consecutive input values >= _threshold keep invoking _onEvent
+                    {
+                        _currentState = State.Enabled;
+                    }
+                }
+
+                else if (_currentValue < _threshold &&
+                     _currentState != State.Disabled)
+                {
+                    _offEvent.Invoke();
+
+                    if (!_discrete)         //Same but for consecutive input values < _threshold to keep invoking _offEvent
+                    {      
+                        _currentState = State.Disabled;
+                    }
+                    
                 }
             }
         }
@@ -70,29 +92,6 @@ namespace Klak.Wiring
 
         State _currentState;
         float _currentValue;
-        float _delayTimer;
-
-        #endregion
-
-        #region MonoBehaviour functions
-
-        void Update()
-        {
-            if (_currentValue >= _threshold)
-            {
-                _delayTimer = 0;
-            }
-            else if (_currentValue < _threshold &&
-                     _currentState != State.Disabled)
-            {
-                _delayTimer += Time.deltaTime;
-                if (_delayTimer >= _delayToOff)
-                {
-                    _offEvent.Invoke();
-                    _currentState = State.Disabled;
-                }
-            }
-        }
 
         #endregion
     }


### PR DESCRIPTION
Update Klak Threshold node with “discrete” checkbox to switch between Kejiro’s original threshold’s behaviour and a new “discrete mode”. Remove “delay to off” functionality.

“Discrete mode” is intended for cases where consecutive input values >= _threshold (or < threshold) should keep invoking the _onEvent (or _offEvent). It probably shouldn’t be used when the threshold input is continuously being sent in, for instance from a Knob Input node, as that would result in the On/OffEvent being invoked constantly and might cause unwanted results.
A good use for the “discrete mode” would be for instance to randomly trigger one of three events every time a certain button is pressed with a patch like this: https://drive.google.com/file/d/1HtbE6EJZzD6CWeM50Ddf2KH_0R-ba5iy/view
Regarding this patch: if two consecutive button presses both result in the Random Value 1 node generating a value > Threshold 1’s, then the original threshold’s behaviour results in Random Value 2 only generating a value once and subsequently only triggering an Event Out node once, only on the first button press. In “discrete mode” the Random Value 2 node will generate a value both times and guarantees an Event Out node will get triggered with each button press.

To make this work properly I removed the “delay to off” functionality, as invoking the Off Event happened in the Update() function because of this delay functionality, which would cause the Off Event to be invoked constantly once a single value < _threshold is reached (until a value >= _threshold is reached). The benefit of having the “discrete mode” seems to outweigh the losing of the “delay to off”, since simply hooking up a Delay node to the Off-outlet of the threshold node has the same result, so no functionality is really lost.

I’m not sure of “discrete” is the best name for the new checkbox though.
