### PR TITLE
New klak node If Then Else

### DIFF
--- a/Assets/Klak/Wiring/Editor/Logic/IfThenElseEditor.cs
+++ b/Assets/Klak/Wiring/Editor/Logic/IfThenElseEditor.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using UnityEditor;
+using System;
+
+namespace Klak.Wiring
+{
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(IfThenElse))]
+    public class IfThenElseEditor : Editor
+    {
+        SerializedProperty _continuousInput;
+        SerializedProperty _condition1;
+        SerializedProperty _useGate;
+        SerializedProperty _gate;
+        SerializedProperty _condition2;
+
+        void OnEnable()
+        {
+            _continuousInput = serializedObject.FindProperty("_continuousInput");
+            _condition1 = serializedObject.FindProperty("_condition1");
+            _useGate = serializedObject.FindProperty("_useGate");
+            _gate = serializedObject.FindProperty("_gate");
+            _condition2 = serializedObject.FindProperty("_condition2");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            if (_useGate.boolValue)
+            {
+                EditorGUILayout.PropertyField(_continuousInput);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(_condition1);
+                EditorGUILayout.PropertyField(_gate);
+                EditorGUILayout.PropertyField(_condition2);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(_useGate);
+            }
+            
+            else
+            {
+                EditorGUILayout.PropertyField(_continuousInput);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(_condition1);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(_useGate);
+            }
+            
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Assets/Klak/Wiring/Logic/IfThenElse.cs
+++ b/Assets/Klak/Wiring/Logic/IfThenElse.cs
@@ -1,0 +1,132 @@
+using UnityEngine;
+
+namespace Klak.Wiring
+{
+    [AddComponentMenu("Klak/Wiring/Logic/IfThenElse")]
+    public class IfThenElse : NodeBase
+    {
+       	#region Editable properties
+
+        [SerializeField]
+        bool _continuousInput;
+
+        [SerializeField]
+        Condition _condition1;
+
+        [SerializeField]
+        bool _useGate;
+
+        [SerializeField]
+        Gate _gate;
+
+        [SerializeField]
+        Condition _condition2;
+
+        #endregion
+
+        #region Node I/O
+
+        [Inlet]
+        public float input {
+            set {
+                if (!enabled) return;
+
+                _inputValue = value;
+
+                if (!_continuousInput) _currentState = State.Dormant;
+
+                _satisfy1 = CheckCondition(_inputValue, _compareValue1, _condition1);
+
+                if (!_useGate)
+                    Invoke(_satisfy1);
+
+                else
+                {
+                    _satisfy2 = CheckCondition(_inputValue, _compareValue2, _condition2);
+
+                    if (_gate == Gate.AND)
+                        Invoke(_satisfy1 && _satisfy2);
+
+                    if (_gate == Gate.OR)
+                        Invoke(_satisfy1 || _satisfy2);
+                }
+            }
+        }
+
+        [Inlet]
+        public float compareValue1 {
+            set{
+                _compareValue1 = value;
+            }
+        }
+
+        [Inlet]
+        public float compareValue2 {
+            set {
+                _compareValue2 = value;
+            }
+        }
+
+        [SerializeField, Outlet]
+        VoidEvent _thenEvent = new VoidEvent();
+
+        [SerializeField, Outlet]
+        VoidEvent _elseEvent = new VoidEvent();
+
+        #endregion
+
+        #region Private members
+
+        enum Gate { OR, AND }
+        enum State { Dormant, BlockThenEvent, BlockElseEvent }
+        State _currentState;
+        enum Condition { Greater, Less, Equal }
+        float _inputValue;
+        float _compareValue1;
+        float _compareValue2;
+        bool _satisfy1;
+        bool _satisfy2;
+
+        private bool CheckCondition(float input, float comparevalue, Condition condition)
+        {
+            switch (condition)
+            {
+                case Condition.Less:
+
+                    return input < comparevalue;
+
+                case Condition.Greater:
+
+                    return input > comparevalue;
+
+                case Condition.Equal:
+
+                    return input == comparevalue;
+            }
+            return false;
+        }
+
+        private void Invoke(bool then)
+        {
+            if (then)
+            {
+                if (_currentState != State.BlockThenEvent)
+                {
+                    _thenEvent.Invoke();
+                    if (_continuousInput) _currentState = State.BlockThenEvent;
+                }
+            }
+
+            else
+            {
+                if (_currentState != State.BlockElseEvent)
+                {
+                    _elseEvent.Invoke();
+                    if (_continuousInput) _currentState = State.BlockElseEvent;
+                }
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
New Klak node with 3 Inlets (Input, Compare Value 1 and Compare Value 2) and two outlets (Then Event and Else Event). 
The Input value can be compared (greater than, less than or equal to) Compare Value 1, and a checkbox can be marked to enable a logic gate (option between AND or OR) to enable a second comparison with Compare Value 2 as well.

There is also a "Continuous Input" checkbox which, if enabled, blocks the re-invoking of the ThenEvent/ElseEvent after it has been invoked, until the ElseEvent/ThenEvent gets invoked. This is to prevent the continuous invoking of events when the input is coming in continuously, for example from a Knob Value.
