### PR TITLE
Klak Update Generic Out Nodes - add ability to set particle system modules properties

### DIFF
--- a/Assets/Klak/Wiring/Output/BoolOut.cs
+++ b/Assets/Klak/Wiring/Output/BoolOut.cs
@@ -50,20 +50,16 @@ namespace Klak.Wiring
         {
             if (_target == null || string.IsNullOrEmpty(_propertyName)) return;
 
+            if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+            {
+                _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
+                _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
+                _boxedStruct = _moduleInfo.GetValue(_target);
+            }
             else
             {
-                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
-                {
-                    _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
-                    _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
-                    _boxedStruct = _moduleInfo.GetValue(_target);
-                }
-
-                else
-                {
-                    _propertyInfo = _target.GetType().GetProperty(_propertyName);
-                }
-            }            
+                _propertyInfo = _target.GetType().GetProperty(_propertyName);
+            }           
         }
         #endregion
     }

--- a/Assets/Klak/Wiring/Output/BoolOut.cs
+++ b/Assets/Klak/Wiring/Output/BoolOut.cs
@@ -14,6 +14,9 @@ namespace Klak.Wiring
         [SerializeField]
         string _propertyName;
 
+        [SerializeField]
+        string _particleSystemModuleName = "<none>";
+
         #endregion
 
         #region Node I/O
@@ -24,7 +27,14 @@ namespace Klak.Wiring
             set
             {
                 if (!enabled || _target == null || _propertyInfo == null) return;
-                _propertyInfo.SetValue(_target, System.Convert.ToBoolean(value), null);
+
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _propertyInfo.SetValue(_boxedStruct, System.Convert.ToBoolean(value), null);
+                }
+                    
+                else _propertyInfo.SetValue(_target, System.Convert.ToBoolean(value), null);
+                
             }
         }
 
@@ -33,13 +43,28 @@ namespace Klak.Wiring
         #region Private members
 
         PropertyInfo _propertyInfo;
+        PropertyInfo _moduleInfo;
+        object _boxedStruct;
 
         void OnEnable()
         {
             if (_target == null || string.IsNullOrEmpty(_propertyName)) return;
-            _propertyInfo = _target.GetType().GetProperty(_propertyName);
-        }
 
+            else
+            {
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
+                    _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
+                    _boxedStruct = _moduleInfo.GetValue(_target);
+                }
+
+                else
+                {
+                    _propertyInfo = _target.GetType().GetProperty(_propertyName);
+                }
+            }            
+        }
         #endregion
     }
 }

--- a/Assets/Klak/Wiring/Output/FloatOut.cs
+++ b/Assets/Klak/Wiring/Output/FloatOut.cs
@@ -37,15 +37,26 @@ namespace Klak.Wiring
         [SerializeField]
         string _propertyName;
 
+        [SerializeField]
+        string _particleSystemModuleName = "<none>";
+
         #endregion
 
         #region Node I/O
 
         [Inlet]
-        public float input {
-            set {
+        public float input 
+        {
+            set 
+            {
                 if (!enabled || _target == null || _propertyInfo == null) return;
-                _propertyInfo.SetValue(_target, value, null);
+
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _propertyInfo.SetValue(_boxedStruct, value, null);
+                }
+                    
+                else _propertyInfo.SetValue(_target, value, null);
             }
         }
 
@@ -54,11 +65,27 @@ namespace Klak.Wiring
         #region Private members
 
         PropertyInfo _propertyInfo;
+        PropertyInfo _moduleInfo;
+        object _boxedStruct;
 
         void OnEnable()
         {
             if (_target == null || string.IsNullOrEmpty(_propertyName)) return;
-            _propertyInfo = _target.GetType().GetProperty(_propertyName);
+
+            else
+            {
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
+                    _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
+                    _boxedStruct = _moduleInfo.GetValue(_target);
+                }
+
+                else
+                {
+                    _propertyInfo = _target.GetType().GetProperty(_propertyName);
+                }
+            }
         }
 
         #endregion

--- a/Assets/Klak/Wiring/Output/IntOut.cs
+++ b/Assets/Klak/Wiring/Output/IntOut.cs
@@ -14,6 +14,9 @@ namespace Klak.Wiring
         [SerializeField]
         string _propertyName;
 
+        [SerializeField]
+        string _particleSystemModuleName = "<none>";
+
         #endregion
 
         #region Node I/O
@@ -24,7 +27,14 @@ namespace Klak.Wiring
             set
             {
                 if (!enabled || _target == null || _propertyInfo == null) return;
-                _propertyInfo.SetValue(_target, System.Convert.ToInt32(value), null);
+
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _propertyInfo.SetValue(_boxedStruct, System.Convert.ToInt32(value), null);
+                }
+                    
+                else _propertyInfo.SetValue(_target, System.Convert.ToInt32(value), null);
+                
             }
         }
 
@@ -33,11 +43,27 @@ namespace Klak.Wiring
         #region Private members
 
         PropertyInfo _propertyInfo;
+        PropertyInfo _moduleInfo;
+        object _boxedStruct;
 
         void OnEnable()
         {
             if (_target == null || string.IsNullOrEmpty(_propertyName)) return;
-            _propertyInfo = _target.GetType().GetProperty(_propertyName);
+
+            else
+            {
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
+                    _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
+                    _boxedStruct = _moduleInfo.GetValue(_target);
+                }
+
+                else
+                {
+                    _propertyInfo = _target.GetType().GetProperty(_propertyName);
+                }
+            }            
         }
 
         #endregion

--- a/Assets/Klak/Wiring/Output/VectorOut.cs
+++ b/Assets/Klak/Wiring/Output/VectorOut.cs
@@ -37,15 +37,27 @@ namespace Klak.Wiring
         [SerializeField]
         string _propertyName;
 
+        [SerializeField]
+        string _particleSystemModuleName = "<none>";
+
         #endregion
 
         #region Node I/O
 
         [Inlet]
-        public Vector3 input {
-            set {
+        public Vector3 input 
+        {
+            set
+            {
                 if (!enabled || _target == null || _propertyInfo == null) return;
-                _propertyInfo.SetValue(_target, value, null);
+
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _propertyInfo.SetValue(_boxedStruct, System.Convert.ToInt32(value), null);
+                }
+                    
+                else _propertyInfo.SetValue(_target, System.Convert.ToInt32(value), null);
+                
             }
         }
 
@@ -54,11 +66,27 @@ namespace Klak.Wiring
         #region Private members
 
         PropertyInfo _propertyInfo;
+        PropertyInfo _moduleInfo;
+        object _boxedStruct;
 
         void OnEnable()
         {
             if (_target == null || string.IsNullOrEmpty(_propertyName)) return;
-            _propertyInfo = _target.GetType().GetProperty(_propertyName);
+
+            else
+            {
+                if (_target.GetType() == typeof(ParticleSystem) && _particleSystemModuleName != "<none>")
+                {
+                    _moduleInfo = _target.GetType().GetProperty(_particleSystemModuleName);
+                    _propertyInfo = _moduleInfo.PropertyType.GetProperty(_propertyName);
+                    _boxedStruct = _moduleInfo.GetValue(_target);
+                }
+
+                else
+                {
+                    _propertyInfo = _target.GetType().GetProperty(_propertyName);
+                }
+            }            
         }
 
         #endregion


### PR DESCRIPTION
Community requested feature: update generic out nodes to be able to set particle system modules properties.

If a particle system is set as the target, modules can be selected in the node's inspector from the "Module" dropdown, and its properties from the "Property" dropdown.
The default module is set to "<none>" so existing videopaks setting (mostely deprecated) particle system properties not belonging to any module are not affected by the update.